### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/handler/register.py
+++ b/handler/register.py
@@ -67,7 +67,7 @@ def unregister(user_id):
 	return{_A:getTextMap(_H)}
 def register(user_id,password):
 	C=password;A=user_id;B=loadUserStatus();D=B.get(str(A),{}).get(_K,'')
-	if C!=PASSWORD:print(f"[{int(time.time())%86400//3600:02d}:{int(time.time())%3600//60:02d}:{time.time()%60:02.0f}] [{Fore.RED}ERROR{Style.RESET_ALL}] User {A}/{D} Input Invalid Password during register account: {C}");return{_A:getTextMap('invalidPassword')}
+	if C!=PASSWORD:print(f"[{int(time.time())%86400//3600:02d}:{int(time.time())%3600//60:02d}:{time.time()%60:02.0f}] [{Fore.RED}ERROR{Style.RESET_ALL}] User {A}/{D} Input Invalid Password during register account.");return{_A:getTextMap('invalidPassword')}
 	if not isinstance(B,dict):return{_A:getTextMap('internalError')}
 	B[str(A)][_D]=True;saveUserStatus(B);print(f"[{int(time.time())%86400//3600:02d}:{int(time.time())%3600//60:02d}:{time.time()%60:02.0f}] [{Fore.BLUE}INFO{Style.RESET_ALL}] User {A}/{D} registered account.");return{_A:getTextMap('registerSuccess')}
 def ban(user_id,reason='',duration=0):


### PR DESCRIPTION
Fixes [https://github.com/FloopInc/GumiPY/security/code-scanning/2](https://github.com/FloopInc/GumiPY/security/code-scanning/2)

To fix the problem, we need to remove the logging of the password in clear text. Instead, we can log a generic message indicating that an invalid password was entered without including the actual password. This way, we maintain the functionality of logging an error without exposing sensitive information.

- Remove the password from the log message on line 70.
- Update the log message to indicate an invalid password attempt without revealing the actual password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
